### PR TITLE
Filter unsupported speech commands, based on NVDA Remote code

### DIFF
--- a/addon/globalPlugins/unicorn/serializer.py
+++ b/addon/globalPlugins/unicorn/serializer.py
@@ -53,7 +53,7 @@ def as_sequence(dct):
 		if not hasattr(speech.commands, name):
 			log.warning("Unknown sequence type received: %r" % name)
 			continue
-		cls = getattr(speech, name)
+		cls = getattr(speech.commands, name)
 		if not issubclass(cls, SEQUENCE_CLASSES):
 			log.warning(f"Unknown sequence type received: {name!r}")
 			continue


### PR DESCRIPTION
Callback commands weren't filtered, causing issues with say all and the like. This is now fixed based on NVDA Remote code.