### PR TITLE
Ad preliminary support for NVDA 2022.1

### DIFF
--- a/addon/globalPlugins/unicorn/__init__.py
+++ b/addon/globalPlugins/unicorn/__init__.py
@@ -28,6 +28,7 @@ import ssl
 from . import callback_manager
 from . import unicorn
 import json
+import addonAPIVersion
 addonHandler.initTranslation()
 
 REMOTE_SHELL_CLASSES = {
@@ -71,7 +72,11 @@ class GlobalPlugin(GlobalPlugin):
 		self.sd_server = None
 		self.sd_relay = None
 		self.sd_bridge = None
-		self.temp_location = os.path.join(shlobj.SHGetFolderPath(0, shlobj.CSIDL_COMMON_APPDATA), 'temp')
+		if addonAPIVersion.CURRENT < (2022, 1, 0):
+			commonAppData = shlobj.SHGetFolderPath(0, shlobj.CSIDL_COMMON_APPDATA)
+		else:
+			commonAppData = shlobj.SHGetKnownFolderPath(shlobj.FolderId.PROGRAM_DATA)
+		self.temp_location = os.path.join(commonAppData, 'temp')
 		self.ipc_file = os.path.join(self.temp_location, 'unicorn.ipc')
 		if globalVars.appArgs.secure:
 			self.handle_secure_desktop()

--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion" : "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2021.2",
+	"addon_lastTestedNVDAVersion" : "2022.1",
 
 }
 


### PR DESCRIPTION
NVDA 2022.1 is in development and will once again break API compat. This pr has at least one required change for this add-on to work on it. I will update it on the go with new changes if necessary and will preserve backwards compat wherever possible.

Cc @Babbage-Jack 